### PR TITLE
Feat: Implémentation du Filtrage par Catégories [US 5.2]

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -1,0 +1,12 @@
+import django_filters
+from .models import Movie
+
+
+class MovieFilter(django_filters.FilterSet):
+    categories = django_filters.CharFilter(
+        field_name="categories__name", lookup_expr="icontains"
+    )
+
+    class Meta:
+        model = Movie
+        fields = ["categories"]

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -80,11 +80,15 @@ class CategorySerializer(serializers.ModelSerializer):
 
 
 class MovieListSerializer(serializers.ModelSerializer):
-    """Sérialiseur pour lister les films avec informations minimales."""
+    """Sérialiseur pour lister les films avec informations minimales, incluant les catégories."""
+
+    categories = serializers.SlugRelatedField(
+        many=True, read_only=True, slug_field="name"
+    )
 
     class Meta:
         model = Movie
-        fields = ("id", "title", "poster_url")
+        fields = ("id", "title", "poster_url", "categories")
 
 
 class MovieDetailSerializer(serializers.ModelSerializer):

--- a/app/tests/test_serializers.py
+++ b/app/tests/test_serializers.py
@@ -12,7 +12,7 @@ class SerializerTest(TestModelSetup):
         """Vérifie que le sérialiseur MovieList contient les champs requis et sérialise correctement."""
 
         data = MovieListSerializer(instance=self.movie_1).data
-        self.assertEqual(set(data.keys()), {"id", "title", "poster_url"})
+        self.assertEqual(set(data.keys()), {"id", "title", "poster_url", "categories"})
         self.assertEqual(data["title"], self.movie_data_1["title"])
         self.assertEqual(
             data["poster_url"],

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 from rest_framework import status
 from django.urls import reverse_lazy
@@ -16,7 +17,7 @@ class TestMovieViewSet(TestModelSetup):
         # Nettoyage des catégories pour éviter les duplicatas
         # Category.objects.all().delete()
 
-        self.url = reverse_lazy("movie-list")
+        self.list_url = reverse_lazy("movie-list")
         self.detail_url = reverse_lazy("movie-detail", kwargs={"pk": self.movie_1.id})
         self.search_url = reverse_lazy("movie-search_movie")
         self.add_movie_url = reverse_lazy("movie-add_movie")
@@ -24,7 +25,7 @@ class TestMovieViewSet(TestModelSetup):
     def test_get_movie_list(self):
         """Vérifie la récupération de la liste des films."""
 
-        response = self.client.get(self.url)
+        response = self.client.get(self.list_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.json()[0]["title"], self.movie_data_1.get("title"))
@@ -143,3 +144,12 @@ class TestMovieViewSet(TestModelSetup):
             "Erreur lors de la récupération des détails du film",
             response.data["detail"],
         )
+
+    def test_filter_by_category(self):
+        response = self.client.get(
+            reverse_lazy("movie-list"), {"categories": "Science Fiction"}
+        )
+        logging.debug(response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for movie in response.data:
+            self.assertIn("Science Fiction", movie["categories"])

--- a/app/views.py
+++ b/app/views.py
@@ -1,10 +1,12 @@
 import logging
 
 from rest_framework import viewsets, status
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from typing import Any
 
+from .filters import MovieFilter
 from .models import Movie
 from .serializers import (
     MovieListSerializer,
@@ -18,11 +20,18 @@ from .services import IMDbService
 
 
 class MovieViewSet(viewsets.ModelViewSet):
-    """VueSet pour gérer les opérations CRUD sur les films, avec recherche et ajout à partir de l'IMDb."""
+    """VueSet pour gérer les opérations CRUD sur les films, avec recherche, ajout à partir de l'IMDb
+    et filtres avancés par catégories, réalisateurs, etc."""
 
     queryset = Movie.objects.all()
     serializer_class = MovieListSerializer
     detail_serializer_class = MovieDetailSerializer
+
+    # Configuration des filtres
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = MovieFilter
+    search_fields = ["title", "summary"]
+    ordering_fields = ["title", "duration"]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialisation de la VueSet pour les films avec injection de dépendance de IMDbService."""

--- a/cinevault_back/settings.py
+++ b/cinevault_back/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "corsheaders",
+    "django_filters",
     "app",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 djangorestframework==3.x.x
+django-filter
 imdbpy
 django-cors-headers
 injector


### PR DESCRIPTION
Cette merge request ajoute la fonctionnalité de filtrage par catégories dans le catalogue de films.

- **Filtrage par Catégories :**
  - Configuration du backend de filtrage dans MovieViewSet pour permettre le filtrage par catégories des films.
  - Mise à jour des sérialiseurs pour inclure et gérer correctement les catégories.
  
- **Architecture Optimisée :**
  - Utilisation de SlugRelatedField pour sérialiser efficacement les catégories par leurs noms.

- **Tests Améliorés :**
  - Ajout de tests pour s'assurer que le filtrage par catégories fonctionne comme prévu.